### PR TITLE
feat: add new metric to mark is patroni service is up or down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ test:
 .PHONY: fmt
 fmt:
 	$(GOFMT) $(PKGS)
+
+.PHONY: run
+run:
+	.build/${GOOS}-${GOARCH}/patroni_exporter --patroni.host="http://localhost" --patroni.port=8008


### PR DESCRIPTION
Add new metric named `patroni_node_up`. Will have value if `1` if patroni service is up and will have value `0` if the patroni service is down.